### PR TITLE
Add deepOverwriteMerge utility

### DIFF
--- a/docs/functions/core.md
+++ b/docs/functions/core.md
@@ -8,7 +8,7 @@ random(): number
 
 This is light-fakery's internal random number generator ([PRNG](https://en.wikipedia.org/wiki/Pseudorandom_number_generator)), although it's exposed in case you want to generate raw random numbers.
 
-It returns numbers between 0 and 1, and by default initializes with a seed based on the current time. To create a deterministic generator, call the [setSeed](/functions/utility#setSeed) function; after that point, all light-fakery functions will use the custom seed.
+It returns numbers between 0 and 1, and by default initializes with a seed based on the current time. To create a deterministic generator, call the [setSeed](/functions/utility#setSeed) function; after that point all light-fakery functions will use the custom seed.
 
 
 ```typescript

--- a/docs/functions/utility.md
+++ b/docs/functions/utility.md
@@ -1,5 +1,47 @@
 # Utility functions
 
+## deepOverwriteMerge
+
+```typescript
+deepOverwriteMerge<T extends object, U extends object>(
+	target: T,
+	overrides?: U,
+): T & U
+```
+
+This method returns a new object with the properties from `overrides` deeply merged
+into `target`.
+
+If a key exists on both `overrides` and `target` then it will be merged if
+both values are objects, or the `overrides` value will win if it is a
+primitive or array.
+
+Keys from `overrides` with falsy values _will_ be written into the result object.
+
+This method is included in `light-fakery` because it helps build a concise pattern
+for type-safe mock data. For example, imagine that `Employee` has 40 properties on it:
+
+```typescript
+import { deepOverwriteMerge } from 'light-fakery'
+
+function mockEmployee(overrides?: Partial<Employee>): Employee {
+
+	const base: Employee = {
+		// ...define sane defaults for all 40 properties!
+	}
+
+	return deepOverwriteMerge(base, overrides)
+}
+```
+The benefit of this pattern is that it allows for creating mocks with only the contextually relevant data, while still preserving the original object's type structure.
+
+In this example `mockEmployee` is a full-fledged `Employee`:
+
+```typescript
+const newEmployee = mockEmployee({ isNew: true })
+```
+
+
 ## times
 
 ```typescript

--- a/docs/functions/utility.md
+++ b/docs/functions/utility.md
@@ -3,10 +3,10 @@
 ## deepOverwriteMerge
 
 ```typescript
-deepOverwriteMerge<T extends object, U extends object>(
+deepOverwriteMerge<T extends Record<string, any>>(
 	target: T,
-	overrides?: U,
-): T & U
+	overrides?: DeepPartial<T>,
+): T {
 ```
 
 This method returns a new object with the properties from `overrides` deeply merged
@@ -18,8 +18,12 @@ primitive or array.
 
 Keys from `overrides` with falsy values _will_ be written into the result object.
 
+This method doesn't support number or Symbol keys.
+
 This method is included in `light-fakery` because it helps build a concise pattern
-for type-safe mock data. For example, imagine that `Employee` has 40 properties on it:
+for type-safe mock data (and this is why the `overrides` type is constrained to
+a partial of the `target` type). For example, imagine that `Employee` has 40
+properties on it:
 
 ```typescript
 import { deepOverwriteMerge } from 'light-fakery'
@@ -33,12 +37,25 @@ function mockEmployee(overrides?: Partial<Employee>): Employee {
 	return deepOverwriteMerge(base, overrides)
 }
 ```
-The benefit of this pattern is that it allows for creating mocks with only the contextually relevant data, while still preserving the original object's type structure.
+The benefit of this pattern is that it allows for creating mocks with only the
+contextually relevant data, while still preserving the original object's type
+structure.
 
 In this example `mockEmployee` is a full-fledged `Employee`:
 
 ```typescript
 const newEmployee = mockEmployee({ isNew: true })
+```
+
+`light-fakery` also includes a convenience `DeepPartial` type to support this
+pattern with nested objects:
+
+```typescript
+import type { DeepPartial } from 'light-fakery'
+
+// ...
+function mockEmployee(overrides?: DeepPartial<Employee>): Employee
+// ...
 ```
 
 
@@ -48,7 +65,8 @@ const newEmployee = mockEmployee({ isNew: true })
 times<T>(n: number, iteratee: (i: number) => T): T[]
 ```
 
-A convenience helper that returns an array of length `n` by invoking `iteratee` n times. The current index is passed into the iteratee function. This is often useful to build lists of fake data.
+A convenience helper that returns an array of length `n` by invoking `iteratee` n times.
+The current index is passed into the iteratee function. This is useful to build lists of fake data.
 
 The implementation here is a simpler version of the same method from [Lodash](https://github.com/lodash/lodash/blob/main/src/times.ts). It isn't quite as bulletproof, so don't expect good behavior if you pass crazy arguments!
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export function setSeed(seed: number): void {
   random = mulberry32(seed)
 }
 
+export { deepOverwriteMerge } from './merge.js'
 export { randomBoolean } from './boolean.js'
 export { randomDate } from './date.js'
 export { randomFromArray } from './from-array.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export function setSeed(seed: number): void {
   random = mulberry32(seed)
 }
 
-export { deepOverwriteMerge } from './merge.js'
+export { deepOverwriteMerge, type DeepPartial } from './merge.js'
 export { randomBoolean } from './boolean.js'
 export { randomDate } from './date.js'
 export { randomFromArray } from './from-array.js'

--- a/src/jargon.ts
+++ b/src/jargon.ts
@@ -6,17 +6,17 @@ import { jargonPhrases } from './data/jargon-phrases.js'
 /**
  * Returns a random jargon adjective. For example, "Decentralized".
  */
- export function randomJargonAdjective(): string {
+export function randomJargonAdjective(): string {
 
-  return randomFromArray(jargonAdjectives)
+	return randomFromArray(jargonAdjectives)
 }
 
 /**
  * Returns a random jargon document title. For example, "Theoretical Aspects of Strategic Planning and Performance".
  */
- export function randomJargonDocumentTitle(): string {
+export function randomJargonDocumentTitle(): string {
 
-  return randomFromArray(jargonDocuments)
+	return randomFromArray(jargonDocuments)
 }
 
 /**
@@ -24,5 +24,5 @@ import { jargonPhrases } from './data/jargon-phrases.js'
  */
 export function randomJargonPhrase(): string {
 
-  return randomFromArray(jargonPhrases)
+	return randomFromArray(jargonPhrases)
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,0 +1,50 @@
+/**
+ * Returns a new object with the properties from `overrides` deeply merged
+ * into `target`.
+ *
+ * If a key exists on both `overrides` and `target` then it will be merged if
+ * both values are objects, or the `overrides` value will win if it is a
+ * primitive or array.
+ *
+ * Keys with falsy values are preserved in the resulting object.
+ */
+export function deepOverwriteMerge<T extends object, U extends object>(
+	target: T,
+	overrides: U,
+): T & U {
+
+	if (!isPlainObject(target)) throw new TypeError(`Target must be a plain object.`)
+	if (!isPlainObject(overrides)) throw new TypeError(`Overrides must be a plain object.`)
+
+	const output = { ...target }
+
+	for (const key of Object.keys(overrides)) {
+
+		if (isPlainObject(output[key]) && isPlainObject(overrides[key])) {
+			output[key] = deepOverwriteMerge(output[key], overrides[key])
+		}
+		else {
+			output[key] = overrides[key]
+		}
+	}
+
+	// The annotation below is necessary because TypeScript's type system is structural,
+	// meaning it doesn't take runtime information into account. In other words, at
+	// compile time it can't use the information from us assigning props from `overrides`
+	// onto `target` in its type definitions.
+	//
+	// We give it the hint that output is going to be `T & U` to work around this.
+	return output as T & U
+}
+
+// We're not bothered to have this function narrow the type because the merge
+// function already expresses the constraint `extends object` on its type arguments.
+// All we need here is a runtime check for our error handling and recursion.
+function isPlainObject(x: unknown): boolean {
+
+	if (x === null) return false
+	if (typeof x !== 'object') return false
+	if (Array.isArray(x)) return false
+
+	return true
+}

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -22,8 +22,9 @@ export function deepOverwriteMerge<T extends object, U extends object>(
 	//
 	// We give it the hint that output is going to be `T & U` to work around this.
 	const output = { ...target } as T & U
-	if (overrides === undefined) return output
 
+	// It's ok for overrides to be undefined, that makes for a smooth DX in some cases.
+	if (overrides === undefined) return output
 	if (!isPlainObject(overrides)) throw new TypeError(`Overrides must be undefined or a plain object.`)
 
 	// If we get here, we have objects for both target and overrides and we can

--- a/test/jargon.test.ts
+++ b/test/jargon.test.ts
@@ -26,7 +26,6 @@ describe('randomJargonDocumentTitle()', () => {
 })
 
 
-
 describe('randomJargonPhrase()', () => {
 
 	beforeEach(() => setSeed(1))

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -53,7 +53,11 @@ describe(`writing basic properties`, () => {
 
 	test(`write an object prop that is a primitive on target`, () => {
 
-		const t = {
+		type TestObject = {
+			a: string | Record<string, string>
+		}
+
+		const t: TestObject = {
 			a: 'target',
 		}
 		const o = {
@@ -74,7 +78,14 @@ describe(`merging object properties`, () => {
 
 	test(`adds override props to target object`, () => {
 
-		const t = {
+		type TestObject = {
+			a: {
+				b?: string
+				c?: string
+			}
+		}
+
+		const t: TestObject = {
 			a: {
 				b: 'target',
 			},
@@ -117,7 +128,19 @@ describe(`merging object properties`, () => {
 
 	test(`supports multi-level nesting`, () => {
 
-		const t = {
+		type TestObject = {
+			a: {
+				b?: string | {
+					c?: string
+					d?: {
+						e?: string
+					}
+				}
+				f?: string
+			}
+		}
+
+		const t: TestObject = {
 			a: {
 				b: 'target',
 				f: 'target',
@@ -211,12 +234,14 @@ describe(`throws on non-object input`, () => {
 		const t1 = [1]
 		const o1 = { a: 'override' }
 
+		// @ts-expect-error - testing runtime behavior of invalid type
 		let call = () => deepOverwriteMerge(t1, o1)
 		expect(call).toThrow(TypeError)
 
 		const t2 = { a: 'target' }
 		const o2 = [1]
 
+		// @ts-expect-error - testing runtime behavior of invalid type
 		call = () => deepOverwriteMerge(t2, o2)
 		expect(call).toThrow(TypeError)
 	})
@@ -226,14 +251,14 @@ describe(`throws on non-object input`, () => {
 		const t1 = null
 		const o1 = { a: 'override' }
 
-		// @ts-expect-error -- testing invalid argument
+		// @ts-expect-error - testing runtime behavior of invalid type
 		let call = () => deepOverwriteMerge(t1, o1)
 		expect(call).toThrow(TypeError)
 
 		const t2 = { a: 'target' }
 		const o2 = null
 
-		// @ts-expect-error -- testing invalid argument
+		// @ts-expect-error - testing runtime behavior of invalid type
 		call = () => deepOverwriteMerge(t2, o2)
 		expect(call).toThrow(TypeError)
 	})
@@ -243,7 +268,7 @@ describe(`throws on non-object input`, () => {
 		const t1 = undefined
 		const o1 = { a: 'override' }
 
-		// @ts-expect-error -- testing invalid argument
+		// @ts-expect-error - testing runtime behavior of invalid type
 		let call = () => deepOverwriteMerge(t1, o1)
 		expect(call).toThrow(TypeError)
 	})
@@ -253,14 +278,14 @@ describe(`throws on non-object input`, () => {
 		const t1 = 1
 		const o1 = { a: 'override' }
 
-		// @ts-expect-error -- testing invalid argument
+		// @ts-expect-error - testing runtime behavior of invalid type
 		let call = () => deepOverwriteMerge(t1, o1)
 		expect(call).toThrow(TypeError)
 
 		const t2 = { a: 'target' }
 		const o2 = 'string'
 
-		// @ts-expect-error -- testing invalid argument
+		// @ts-expect-error - testing runtime behavior of invalid type
 		call = () => deepOverwriteMerge(t2, o2)
 		expect(call).toThrow(TypeError)
 	})

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -238,20 +238,13 @@ describe(`throws on non-object input`, () => {
 		expect(call).toThrow(TypeError)
 	})
 
-	test(`throws when undefined values are passed`, () => {
+	test(`throws when undefined is passed for target`, () => {
 
 		const t1 = undefined
 		const o1 = { a: 'override' }
 
 		// @ts-expect-error -- testing invalid argument
 		let call = () => deepOverwriteMerge(t1, o1)
-		expect(call).toThrow(TypeError)
-
-		const t2 = { a: 'target' }
-		const o2 = undefined
-
-		// @ts-expect-error -- testing invalid argument
-		call = () => deepOverwriteMerge(t2, o2)
 		expect(call).toThrow(TypeError)
 	})
 
@@ -275,7 +268,7 @@ describe(`throws on non-object input`, () => {
 
 describe(`edge cases`, () => {
 
-	test(`overrides is an empty object`, () => {
+	test(`returns target when overrides is an empty object`, () => {
 
 		const t = {
 			a: 'target',
@@ -285,7 +278,15 @@ describe(`edge cases`, () => {
 		expect(deepOverwriteMerge(t, o)).toEqual({ a: 'target' })
 	})
 
-	test(`target and overrides are the same exact object`, () => {
+	test(`returns target when overrides is undefined`, () => {
+
+		const t = { a: 'target' }
+		const o = undefined
+
+		expect(deepOverwriteMerge(t, o)).toEqual(t)
+	})
+
+	test(`returns target when target and overrides are the same exact object`, () => {
 
 		const t = {
 			a: 'target',

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { deepOverwriteMerge } from '../src/merge'
+import { deepOverwriteMerge } from '../src/index.js'
 
 describe(`writing basic properties`, () => {
 

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from 'vitest'
+import { deepOverwriteMerge } from '../src/merge'
+
+describe(`writing basic properties`, () => {
+
+	test(`write a primitive prop that isn't on target`, () => {
+
+		const t = {}
+		const o = { a: 'override' }
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: 'override' })
+	})
+
+	test(`write a primitive prop that is on target`, () => {
+
+		const t = { a: 'target' }
+		const o = { a: 'override' }
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: 'override' })
+	})
+
+	test(`write an undefined prop that isn't on target`, () => {
+
+		const t = {}
+		const o = { a: undefined }
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: undefined })
+	})
+
+	test(`write an undefined prop that is on target`, () => {
+
+		const t = { a: 'target' }
+		const o = { a: undefined }
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: undefined })
+	})
+
+	test(`write an object prop that isn't on target`, () => {
+
+		const t = {}
+		const o = {
+			a: {
+				b: 'override',
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: 'override',
+			},
+		})
+	})
+
+	test(`write an object prop that is a primitive on target`, () => {
+
+		const t = {
+			a: 'target',
+		}
+		const o = {
+			a: {
+				b: 'override',
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: 'override',
+			},
+		})
+	})
+})
+
+describe(`merging object properties`, () => {
+
+	test(`adds override props to target object`, () => {
+
+		const t = {
+			a: {
+				b: 'target',
+			},
+		}
+		const o = {
+			a: {
+				c: 'override',
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: 'target',
+				c: 'override',
+			},
+		})
+	})
+
+	test(`overrides target props if they exist`, () => {
+
+		const t = {
+			a: {
+				b: 'target',
+				c: 'target',
+			},
+		}
+		const o = {
+			a: {
+				b: 'override',
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: 'override',
+				c: 'target',
+			},
+		})
+	})
+
+	test(`supports multi-level nesting`, () => {
+
+		const t = {
+			a: {
+				b: 'target',
+				f: 'target',
+			},
+		}
+		const o = {
+			a: {
+				b: {
+					c: 'override-1',
+					d: {
+						e: 'override-2',
+					},
+				},
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: {
+					c: 'override-1',
+					d: {
+						e: 'override-2',
+					},
+				},
+				f: 'target',
+			},
+		})
+	})
+
+	test(`arrays should be overwritten, not merged`, () => {
+
+		const t = {
+			a: ['target'],
+		}
+		const o = {
+			a: ['override'],
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: ['override'] })
+	})
+
+	test(`merges undefined values onto target`, () => {
+
+		const t = {
+			a: {
+				b: 'target',
+				c: 'target',
+			},
+		}
+		const o = {
+			a: {
+				b: undefined,
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: undefined,
+				c: 'target',
+			},
+		})
+	})
+
+	test(`retains undefined values on target`, () => {
+
+		const t = {
+			a: {
+				b: 'target',
+				c: undefined,
+			},
+		}
+		const o = {
+			a: {
+				b: 'override',
+			},
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({
+			a: {
+				b: 'override',
+				c: undefined,
+			},
+		})
+	})
+})
+
+describe(`throws on non-object input`, () => {
+
+	test(`throws when arrays are passed`, () => {
+
+		const t1 = [1]
+		const o1 = { a: 'override' }
+
+		let call = () => deepOverwriteMerge(t1, o1)
+		expect(call).toThrow(TypeError)
+
+		const t2 = { a: 'target' }
+		const o2 = [1]
+
+		call = () => deepOverwriteMerge(t2, o2)
+		expect(call).toThrow(TypeError)
+	})
+
+	test(`throws when null values are passed`, () => {
+
+		const t1 = null
+		const o1 = { a: 'override' }
+
+		// @ts-expect-error -- testing invalid argument
+		let call = () => deepOverwriteMerge(t1, o1)
+		expect(call).toThrow(TypeError)
+
+		const t2 = { a: 'target' }
+		const o2 = null
+
+		// @ts-expect-error -- testing invalid argument
+		call = () => deepOverwriteMerge(t2, o2)
+		expect(call).toThrow(TypeError)
+	})
+
+	test(`throws when undefined values are passed`, () => {
+
+		const t1 = undefined
+		const o1 = { a: 'override' }
+
+		// @ts-expect-error -- testing invalid argument
+		let call = () => deepOverwriteMerge(t1, o1)
+		expect(call).toThrow(TypeError)
+
+		const t2 = { a: 'target' }
+		const o2 = undefined
+
+		// @ts-expect-error -- testing invalid argument
+		call = () => deepOverwriteMerge(t2, o2)
+		expect(call).toThrow(TypeError)
+	})
+
+	test(`throws when primitive values are passed`, () => {
+
+		const t1 = 1
+		const o1 = { a: 'override' }
+
+		// @ts-expect-error -- testing invalid argument
+		let call = () => deepOverwriteMerge(t1, o1)
+		expect(call).toThrow(TypeError)
+
+		const t2 = { a: 'target' }
+		const o2 = 'string'
+
+		// @ts-expect-error -- testing invalid argument
+		call = () => deepOverwriteMerge(t2, o2)
+		expect(call).toThrow(TypeError)
+	})
+})
+
+describe(`edge cases`, () => {
+
+	test(`overrides is an empty object`, () => {
+
+		const t = {
+			a: 'target',
+		}
+		const o = {}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: 'target' })
+	})
+
+	test(`target and overrides are the same exact object`, () => {
+
+		const t = {
+			a: 'target',
+		}
+
+		const result = deepOverwriteMerge(t, t)
+
+		expect(result).toEqual({ a: 'target' })
+		expect(result).not.toBe(t) // it should be a new value
+	})
+})


### PR DESCRIPTION
I've been meaning to add this for a while, but never could quite wrap my head around the TypeScript implications.

This time I'm satisfied I understand why it does actually need the single type annotation.