### PR TITLE
Fix date handling in deepOverwriteMerge

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -59,6 +59,9 @@ function isPlainObject(x: unknown): boolean {
 	// Arrays have typeof === 'object' too, but we don't want to merge them.
 	if (Array.isArray(x)) return false
 
+	// Dates have typeof === 'object', but should be overwritten rather than merged.
+	if (x instanceof Date) return false
+
 	return true
 }
 

--- a/test/date.test.ts
+++ b/test/date.test.ts
@@ -25,12 +25,12 @@ describe('randomDate()', () => {
 	test('produces a valid date', () => {
 
 		const date = randomDate({
-			from: new Date('January 1, 2023'),
-			to: new Date('December 31, 2023'),
+			from: new Date('2023-01-01T00:00:00.000Z'),
+			to: new Date('2023-12-31T00:00:00.000Z'),
 		})
 
 		expect(isValidDate(date), 'it exists').toBe(true)
-		expect(date, 'it matches').toEqual(new Date('2023-08-17T12:07:04.602Z'))
+		expect(date, 'it matches').toEqual(new Date('2023-08-17T06:07:04.602Z'))
 	})
 
 	test('produces random dates', () => {

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -182,6 +182,21 @@ describe(`merging object properties`, () => {
 		expect(deepOverwriteMerge(t, o)).toEqual({ a: ['override'] })
 	})
 
+	test(`dates should be overwritten, not merged`, () => {
+
+		const targetDate = new Date('2020-01-01T00:00:00.000Z')
+		const overrideDate = new Date('2021-01-01T00:00:00.000Z')
+
+		const t = {
+			a: targetDate,
+		}
+		const o = {
+			a: overrideDate,
+		}
+
+		expect(deepOverwriteMerge(t, o)).toEqual({ a: overrideDate })
+	})
+
 	test(`merges undefined values onto target`, () => {
 
 		const t = {


### PR DESCRIPTION
- Date objects attempted to merge and resulted in an empty object, they should now be overwritten.
- The "produces a valid date" test was time zone specific and would consistently fail for me.